### PR TITLE
Fix : 모바일 퍼스트로 가로 너비 고정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,8 +16,8 @@ export default function RootLayout({
     pathname.startsWith("/chat-list/");
 
   return (
-    <html lang="ko">
-      <body>
+    <html lang="ko" className="bg-gray-200">
+      <body className="max-w-md mx-auto min-h-screen bg-white">
         <main>{children}</main>
         {!hideNav && <Navigation />}
       </body>


### PR DESCRIPTION
화면의 너비가  아무리 넓어져도 448px이후 부터는body요소가  고정 됩니다.  html의 배경을 회색으로 하여 화면이 넓어졌을때 어디까지가 body요소인지 구별할 수 있습니다.