### PR TITLE
Style : 네비게이션 스타일링

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,29 +1,64 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  HiOutlineMap,
+  HiOutlineChatBubbleOvalLeftEllipsis,
+  HiOutlineChartBar,
+  HiOutlineTrophy,
+  HiOutlineUser,
+} from "react-icons/hi2";
 
 export default function Navigation() {
+  const currentPath = usePathname();
   return (
-    <>
-      <nav>
-        <ul>
-          <li>
-            <Link href={"/"}>맵</Link>
-          </li>
-          <li>
-            <Link href={"/chat-list"}>채팅방 목록</Link>
-          </li>
-          <li>
-            <Link href={"/chart"}>기록</Link>
-          </li>
-          <li>
-            <Link href={"/ranking"}>랭킹</Link>
-          </li>
-          <li>
-            <Link href={"/mypage"}>마이페이지</Link>
-          </li>
-        </ul>
-      </nav>
-    </>
+    <nav className="btm-nav max-w-md mx-auto">
+      <Link
+        href={"/"}
+        className={`text-primary ${
+          currentPath === "/" ? "active" : "text-gray-500"
+        }`}
+      >
+        <HiOutlineMap size={25} />
+        <span className="btm-nav-label">맵</span>
+      </Link>
+      <Link
+        href={"/chat-list"}
+        className={`text-primary ${
+          currentPath === "/chat-list" ? "active" : "text-gray-500"
+        }`}
+      >
+        <HiOutlineChatBubbleOvalLeftEllipsis size={25} />
+        <span className="btm-nav-label">채팅</span>
+      </Link>
+      <Link
+        href={"/ranking"}
+        className={`text-primary ${
+          currentPath === "/ranking" ? "active" : "text-gray-500"
+        }`}
+      >
+        <HiOutlineTrophy size={25} />
+        <span className="btm-nav-label">랭킹</span>
+      </Link>
+      <Link
+        href={"/chart"}
+        className={`text-primary ${
+          currentPath === "/chart" ? "active" : "text-gray-500"
+        }`}
+      >
+        <HiOutlineChartBar size={25} />
+        <span className="btm-nav-label">기록</span>
+      </Link>
+      <Link
+        href={"/mypage"}
+        className={`text-primary ${
+          currentPath === "/mypage" ? "active" : "text-gray-500"
+        }`}
+      >
+        <HiOutlineUser size={25} />
+        <span className="btm-nav-label">마이 페이지</span>
+      </Link>
+    </nav>
   );
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -17,7 +17,7 @@ export default function Navigation() {
       <Link
         href={"/"}
         className={`text-primary ${
-          currentPath === "/" ? "active" : "text-gray-500"
+          currentPath === "/" ? "active" : "text-gray-400"
         }`}
       >
         <HiOutlineMap size={25} />
@@ -26,7 +26,7 @@ export default function Navigation() {
       <Link
         href={"/chat-list"}
         className={`text-primary ${
-          currentPath === "/chat-list" ? "active" : "text-gray-500"
+          currentPath === "/chat-list" ? "active" : "text-gray-400"
         }`}
       >
         <HiOutlineChatBubbleOvalLeftEllipsis size={25} />
@@ -35,7 +35,7 @@ export default function Navigation() {
       <Link
         href={"/ranking"}
         className={`text-primary ${
-          currentPath === "/ranking" ? "active" : "text-gray-500"
+          currentPath === "/ranking" ? "active" : "text-gray-400"
         }`}
       >
         <HiOutlineTrophy size={25} />
@@ -44,7 +44,7 @@ export default function Navigation() {
       <Link
         href={"/chart"}
         className={`text-primary ${
-          currentPath === "/chart" ? "active" : "text-gray-500"
+          currentPath === "/chart" ? "active" : "text-gray-400"
         }`}
       >
         <HiOutlineChartBar size={25} />
@@ -53,7 +53,7 @@ export default function Navigation() {
       <Link
         href={"/mypage"}
         className={`text-primary ${
-          currentPath === "/mypage" ? "active" : "text-gray-500"
+          currentPath === "/mypage" ? "active" : "text-gray-400"
         }`}
       >
         <HiOutlineUser size={25} />


### PR DESCRIPTION
Background
---
네비게이션 바를 하단에 고정하고 아이콘과 텍스트가 같이 있게 스타일링 했습니다. 
맵, 채팅, 랭킹, 기록, 마이 페이지 순으로 구현했습니다.

Test
---
클릭시 잘 이동 되며  해당하는 페이지일시 active 클래스가 추가 되어 각 Link위에 가로줄이 생깁니다.
해당 하지 않는 Link들은 회색 처리 했습니다.

Discuss
---
순서나 색 등 변경하고 싶은 부분 있으시면 댓글로 남겨주세요!

![스크린샷 2024-10-01 10 21 25](https://github.com/user-attachments/assets/cec703b4-b3c3-4c8d-86b7-97204c8cd2e1)