### PR TITLE
Feature : 랭킹 페이지 추가

### DIFF
--- a/db.json
+++ b/db.json
@@ -83,13 +83,13 @@
       "rank": 2,
       "userId": 2,
       "nicknName": "minji_k",
-      "total_distance": 30
+      "total_distance": 30.5
     },
     {
       "rank": 3,
       "userId": 3,
       "nicknName": "김제로",
-      "total_distance": 29
+      "total_distance": 29.3
     },
     {
       "rank": 4,
@@ -131,7 +131,7 @@
       "rank": 10,
       "userId": 10,
       "nicknName": "hr_the_cat",
-      "total_distance": 15
+      "total_distance": 15.5
     }
   ],
   "Record": [

--- a/db.json
+++ b/db.json
@@ -74,10 +74,64 @@
   ],
   "Ranking": [
     {
-      "rank_id": 1,
-      "user_id": 1,
-      "total_distance": 100.0,
-      "rank": 1
+      "rank": 1,
+      "userId": 1,
+      "nicknName": "러너스하이",
+      "total_distance": 32
+    },
+    {
+      "rank": 2,
+      "userId": 2,
+      "nicknName": "minji_k",
+      "total_distance": 30
+    },
+    {
+      "rank": 3,
+      "userId": 3,
+      "nicknName": "김제로",
+      "total_distance": 29
+    },
+    {
+      "rank": 4,
+      "userId": 4,
+      "nicknName": "혠이",
+      "total_distance": 28
+    },
+    {
+      "rank": 5,
+      "userId": 5,
+      "nicknName": "Danielle",
+      "total_distance": 26
+    },
+    {
+      "rank": 6,
+      "userId": 6,
+      "nicknName": "피닉스러너",
+      "total_distance": 25
+    },
+    {
+      "rank": 7,
+      "userId": 7,
+      "nicknName": "Hanni_P",
+      "total_distance": 24.3
+    },
+    {
+      "rank": 8,
+      "userId": 8,
+      "nicknName": "러닝버니",
+      "total_distance": 23
+    },
+    {
+      "rank": 9,
+      "userId": 9,
+      "nicknName": "새청바지",
+      "total_distance": 20
+    },
+    {
+      "rank": 10,
+      "userId": 10,
+      "nicknName": "hr_the_cat",
+      "total_distance": 15
     }
   ],
   "Record": [

--- a/src/app/ranking/loading.tsx
+++ b/src/app/ranking/loading.tsx
@@ -1,3 +1,15 @@
 export default async function RankingLoading() {
-  return <div>Loading</div>;
+  const currentMonth = new Date().getMonth() + 1;
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-8 text-center">
+        🏆 {currentMonth}월 랭킹 🏆
+      </h1>
+      <ul className="space-y-3">
+        {Array.from({ length: 10 }).map((_, index) => (
+          <div key={index} className="skeleton h-16"></div>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -2,10 +2,7 @@ import { Ranking } from "@/types/Ranking";
 
 export default async function RankingPage() {
   const currentMonth = new Date().getMonth() + 1;
-
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/Ranking`, {
-    cache: "no-store",
-  });
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/Ranking`);
   const rankingList: Ranking[] = await res.json();
 
   return (

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -1,20 +1,50 @@
+import { Ranking } from "@/types/Ranking";
+
 export default async function RankingPage() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/Ranking`);
-  const rankingData = await res.json();
+  const currentMonth = new Date().getMonth() + 1;
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/Ranking`, {
+    cache: "no-store",
+  });
+  const rankingList: Ranking[] = await res.json();
 
   return (
-    <div className="ranking-page p-8">
-      <h1 className="text-2xl font-bold mb-4">🏆 Running Rankings 🏆</h1>
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-8 text-center">
+        🏆 {currentMonth}월 랭킹 🏆
+      </h1>
       <ul className="space-y-3">
-        {rankingData.map((item: any) => (
+        {rankingList.map((ranking) => (
           <li
-            key={item.userId}
-            className="ranking-item flex justify-between items-center bg-gray-100 p-4 rounded-lg shadow-md"
+            key={ranking.userId}
+            className={`flex justify-between items-center p-4 rounded-lg shadow-md ${
+              ranking.rank === 1
+                ? "bg-yellow-300"
+                : ranking.rank === 2
+                ? "bg-gray-300"
+                : ranking.rank === 3
+                ? "bg-orange-300"
+                : "bg-gray-100"
+            }`}
           >
-            <span className="rank text-lg font-semibold">{item.rank}위</span>
-            <span className="nickname text-lg">{item.nicknName}</span>
-            <span className="distance text-gray-600">
-              {item.total_distance} km
+            <span
+              className={`rank font-semibold w-10 ${
+                ranking.rank <= 3 ? "text-3xl" : "text-lg"
+              }`}
+            >
+              {ranking.rank === 1
+                ? "🥇"
+                : ranking.rank === 2
+                ? "🥈"
+                : ranking.rank === 3
+                ? "🥉"
+                : `${ranking.rank} 위`}
+            </span>
+            <span className="nickname text-lg flex-1 text-center">
+              {ranking.nicknName}
+            </span>
+            <span className="distance text-gray-600 w-16 text-right">
+              {ranking.total_distance} km
             </span>
           </li>
         ))}

--- a/src/types/Ranking.ts
+++ b/src/types/Ranking.ts
@@ -1,0 +1,6 @@
+export interface Ranking {
+  rank: number;
+  userId: number;
+  nicknName: string;
+  total_distance: number;
+}


### PR DESCRIPTION
Background
---
db.json에 랭킹 데이터 10위까지(원래는 20위) 추가 하고 페이지와 로딩 구현했습니다.
types/Ranking.ts에 Ranking 타입 정의했습니다.

Test
---
상단에 현재 월 랭킹으로 잘뜹니다.
1위, 2위, 3위는 🥇🥈🥉로 잘 대체 되어 나옵니다.
또한 배경 색도 다르게 잘 나옵니다.
로딩중 스켈레톤도 잘 나옵니다.

Discuss
---
현재는 랭킹 리스트 부분만 분리해서 그곳만 로딩 하는게 아닌 전체 페이지가 로딩 페이지로 대체 됩니다.
따라서 loading.tsx에서도 현재 월을 받아와서 h1요소에 보여주는 부분이 중복되어있습니다.
랭킹 리스트(데이터 패칭), 랭킹 리스트 로딩 컴포넌트로 분리시켜 Page.tsx안에서 Suspense로 부분 로딩만 주어야 할지,
아니면 간단한 페이지이므로 이대로 둘지 고민입니다.

![스크린샷 2024-10-01 14 49 07](https://github.com/user-attachments/assets/8ca7952f-d4e1-496d-9773-53764cd1aac0)
![스크린샷 2024-10-01 14 48 44](https://github.com/user-attachments/assets/a5e27d4d-37f8-47c7-b036-e6378ebf88dd)